### PR TITLE
Update OneClickDesktop.sh

### DIFF
--- a/OneClickDesktop.sh
+++ b/OneClickDesktop.sh
@@ -19,8 +19,8 @@
 #You can change the Guacamole source file download link here.
 #Check https://guacamole.apache.org/releases/ for the latest stable version.
 
-GUACAMOLE_DOWNLOAD_LINK="https://mirrors.ocf.berkeley.edu/apache/guacamole/1.2.0/source/guacamole-server-1.2.0.tar.gz"
-GUACAMOLE_VERSION="1.2.0"
+GUACAMOLE_DOWNLOAD_LINK="https://mirrors.ocf.berkeley.edu/apache/guacamole/1.5.2/source/guacamole-server-1.5.2.tar.gz"
+GUACAMOLE_VERSION="1.5.2"
 
 #By default, this script only works on Ubuntu 18/20, Debian 10, and CentOS 7/8.
 #You can disable the OS check switch below and tweak the code yourself to try to install it in other OS versions.

--- a/OneClickDesktop.sh
+++ b/OneClickDesktop.sh
@@ -26,7 +26,7 @@ GUACAMOLE_VERSION="1.5.2"
 #You can disable the OS check switch below and tweak the code yourself to try to install it in other OS versions.
 #Please do note that if you choose to use this script on OS other than Ubuntu 18/20, Debian 10, or CentOS 7/8, you might mess up your OS.  Please keep a backup of your server before installation.
 
-OS_CHECK_ENABLED=ON
+OS_CHECK_ENABLED=OFF
 
 
 


### PR DESCRIPTION
--2023-11-06 17:22:37--  https://mirrors.ocf.berkeley.edu/apache/guacamole/1.2.0/source/guacamole-server-1.2.0.tar.gz
Resolving mirrors.ocf.berkeley.edu (mirrors.ocf.berkeley.edu)... 169.229.200.70, 2607:f140:0:32::70
Connecting to mirrors.ocf.berkeley.edu (mirrors.ocf.berkeley.edu)|169.229.200.70|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2023-11-06 17:22:37 ERROR 404: Not Found.

tar (child): guacamole-server-1.2.0.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
OneClickDesktop.sh: line 239: cd: /root/guacamole-server-1.2.0: No such file or directory
Start building Guacamole Server from source...
OneClickDesktop.sh: line 241: ./configure: No such file or directory

Missing dependencies.

1.2.0 is missing, this needs to be updated to 1.5.2